### PR TITLE
Mirror of github glb-director PR IssueNumber 116

### DIFF
--- a/src/glb-director-xdp/packaging/xdp-root-shim@.service
+++ b/src/glb-director-xdp/packaging/xdp-root-shim@.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=XDP Root Shim provides a root array to bind and replace XDP programs on a given interface
-After=network.target network-online.target
-Wants=network-online.target
+After=network.target
+Before=network-online.target
+Wants=network.target
 
 [Service]
 # Allow the service to notify systemd when it has finished activating.


### PR DESCRIPTION
Mirror of github glb-director PR IssueNumber 116
Bringing up XDP on a new interface for the first time causes the interface to temporarily go down and back up. By ensuring that the XDP shim is brought online prior to `network-online.target`, we ensure that programs that rely on stable network interfaces are not started until this process has completed.
